### PR TITLE
Bug if profile had no url

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -109,7 +109,7 @@ def get_profile(bot, trigger, match):
            ' | Tweets: {user.statuses_count}'
            ' | Following: {user.friends_count}'
            ' | Followers: {user.followers_count}').format(user=user, desc=desc)
-    if url is not None:
+    if profile_url is not None:
         message += (' | URL: ' + profile_url)
 
     bot.say(message)


### PR DESCRIPTION
UnboundLocalError: local variable 'url' referenced before assignment (file "/usr/local/lib/python3.5/dist-packages/sopel_modules/twitter/twitter.py", line 112, in get_profile)